### PR TITLE
fix: Security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,16 +14,15 @@
   "dependencies": {
     "os": "0.1.1",
     "querystring": "0.2.0",
-    "request": "2.81.0",
-    "telesignsdk": "^2.0.1",
+    "request": "^2.88.0",
     "urijs": "1.18.10",
     "uuid-v4.js": "1.0.2"
   },
   "devDependencies": {
     "istanbul": "^0.4.5",
     "proxyquire": "^1.8.0",
-    "sinon": "^3.0.0",
-    "tap-spec": "^4.1.1",
+    "sinon": "^7.2.7",
+    "tap-spec": "^5.0.0",
     "tape": "^4.7.0"
   },
   "keywords": [


### PR DESCRIPTION
see https://github.com/TeleSign/node_telesign/issues/5

- update `request` version
- remove `telesignsdk` (should using `npm link` when you writing examples, or just require('../index'))