### PR TITLE
Unpin urijs to allow applying security updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "os": "0.1.1",
     "querystring": "0.2.0",
     "request": "^2.88.0",
-    "urijs": "1.18.10",
+    "urijs": "^1.18.10",
     "uuid-v4.js": "1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The currently-pinned version is subject to a number of high-severity security issues:

- Authorization Bypass Through User-Controlled Key in urijs - https://github.com/advisories/GHSA-gcv8-gh4r-25x6
- Open Redirect in urijs - https://github.com/advisories/GHSA-8h2f-7jc4-7m3m
- Incorrect protocol extraction via \r, \n and \t characters - https://github.com/advisories/GHSA-3vjf-82ff-p4r3
- Leading white space bypasses protocol validation - https://github.com/advisories/GHSA-gmv4-r438-p67f
- Hostname spoofing via backslashes in URL - https://github.com/advisories/GHSA-p6j9-7xhc-rhwp
- Hostname spoofing via backslashes in URL  - https://github.com/advisories/GHSA-89gv-h8wf-cg8r
- Hostname spoofing via backslashes in URL - https://github.com/advisories/GHSA-3329-pjwv-fjpg
- URL Confusion When Scheme Not Supplied in medialize/uri.js - https://github.com/advisories/GHSA-g694-m8vq-gv9h